### PR TITLE
chore: update gptscript version v0.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gptscript-ai/gptscript",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gptscript-ai/gptscript",
-      "version": "0.4.2",
+      "version": "0.5.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -5047,9 +5047,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.0.tgz",
-      "integrity": "sha512-/Wo7DcT0u5HUV486xg675HtjNd3BXZ6xDbzsCUZPt5iw8bTQ63bP0Raut3mvro9u+CUyq7YQd8Cx55fsZXxqLQ==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
+      "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
       "dependencies": {
         "chownr": "^2.0.0",
         "fs-minipass": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gptscript-ai/gptscript",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "description": "Run gptscript in node.js",
   "main": "lib/gptscript.js",
   "repository": {

--- a/scripts/install-binary.js
+++ b/scripts/install-binary.js
@@ -66,7 +66,7 @@ if (process.platform === 'win32') {
 const gptscript_info = {
     name: "gptscript",
     url: "https://github.com/gptscript-ai/gptscript/releases/download/",
-    version: "v0.4.2"
+    version: "v0.5.0"
 }
 
 const pltfm = {

--- a/src/gptscript.js
+++ b/src/gptscript.js
@@ -7,7 +7,7 @@ function getCmdPath() {
 }
 
 const optToArg = {
-    cache: "--cache=",
+    cache: "--disable-cache=",
     cacheDir: "--cache-dir=",
 }
 
@@ -15,7 +15,11 @@ function toArgs(opts) {
     let args = ["--quiet=false"];
     for (const [key, value] of Object.entries(opts)) {
         if (optToArg[key]) {
-            args.push(optToArg[key] + value);
+            if (key === "cache") {
+                args.push(optToArg[key] + !value);
+            } else {
+                args.push(optToArg[key] + value);
+            }
         }
     }
     return args;


### PR DESCRIPTION
Bump node package version to v0.5.0
update to new `--disable-cache` flag without breaking API.