### PR TITLE
feat: add remote SDK environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ you will see "Hello, World!" in the output of the command.
 These are optional options that can be passed to the various `exec` functions.
 None of the options is required, and the defaults will reduce the number of calls made to the Model API.
 
-- `cache`: Enable or disable caching. Default (true).
+- `disableCache`: Enable or disable caching. Default (true).
 - `cacheDir`: Specify the cache directory.
 - `quiet`: No output logging
 - `chdir`: Change current working directory
@@ -99,7 +99,7 @@ Executes a GPT script file with optional input and arguments. The script is rela
 const gptscript = require('@gptscript-ai/gptscript');
 
 const opts = {
-    cache: false,
+    disableCache: false,
 };
 
 async function execFile() {
@@ -120,7 +120,7 @@ Executes a gptscript with optional input and arguments, and returns the output s
 const gptscript = require('@gptscript-ai/gptscript');
 
 const opts = {
-    cache: false,
+    disableCache: false,
 };
 
 const t = new gptscript.Tool({
@@ -154,7 +154,7 @@ Executes a gptscript with optional input and arguments, and returns the output a
 const gptscript = require('@gptscript-ai/gptscript');
 
 const opts = {
-    cache: false,
+    disableCache: false,
 };
 
 const t = new gptscript.Tool({
@@ -192,7 +192,7 @@ The script is relative to the callers source directory.
 const gptscript = require('@gptscript-ai/gptscript');
 
 const opts = {
-    cache: false,
+    disableCache: false,
 };
 
 async function streamExecFile() {
@@ -222,7 +222,7 @@ The script is relative to the callers source directory.
 const gptscript = require('@gptscript-ai/gptscript');
 
 const opts = {
-    cache: false,
+    disableCache: false,
 };
 
 async function streamExecFileWithEvents() {
@@ -252,19 +252,19 @@ async function streamExecFileWithEvents() {
 
 ### Tool Parameters
 
-| Argument          | Type           | Default     | Description                                                                                   |
-|-------------------|----------------|-------------|-----------------------------------------------------------------------------------------------|
-| name              | string         | `""`        | The name of the tool. Optional only on the first tool if there are multiple tools defined.                                                                         |
-| description       | string         | `""`        | A brief description of what the tool does, this is important for explaining to the LLM when it should be used.                                                    |
-| tools             | array          | `[]`        | An array of tools that the current tool might depend on or use.                               |
-| maxTokens         | number/undefined | `undefined` | The maximum number of tokens to be used. Prefer `undefined` for uninitialized or optional values. |
-| model             | string         | `""`        | The model that the tool uses, if applicable.                                                  |
-| cache             | boolean        | `true`      | Whether caching is enabled for the tool.                                                      |
-| temperature       | number/undefined | `undefined` | The temperature setting for the model, affecting randomness. `undefined` for default behavior. |
-| args              | object         | `{}`        | Additional arguments specific to the tool, described by key-value pairs.                      |
-| internalPrompt    | boolean  | `false`        | An internal prompt used by the tool, if any.                                                  |
-| instructions      | string         | `""`        | Instructions on how to use the tool.                                                          |
-| jsonResponse      | boolean        | `false`     | Whether the tool returns a JSON response instead of plain text. You must include the word 'json' in the body of the prompt                               |
+| Argument       | Type           | Default     | Description                                                                                   |
+|----------------|----------------|-------------|-----------------------------------------------------------------------------------------------|
+| name           | string         | `""`        | The name of the tool. Optional only on the first tool if there are multiple tools defined.                                                                         |
+| description    | string         | `""`        | A brief description of what the tool does, this is important for explaining to the LLM when it should be used.                                                    |
+| tools          | array          | `[]`        | An array of tools that the current tool might depend on or use.                               |
+| maxTokens      | number/undefined | `undefined` | The maximum number of tokens to be used. Prefer `undefined` for uninitialized or optional values. |
+| model          | string         | `""`        | The model that the tool uses, if applicable.                                                  |
+| disableCache   | boolean        | `true`      | Whether caching is enabled for the tool.                                                      |
+| temperature    | number/undefined | `undefined` | The temperature setting for the model, affecting randomness. `undefined` for default behavior. |
+| args           | object         | `{}`        | Additional arguments specific to the tool, described by key-value pairs.                      |
+| internalPrompt | boolean  | `false`        | An internal prompt used by the tool, if any.                                                  |
+| instructions   | string         | `""`        | Instructions on how to use the tool.                                                          |
+| jsonResponse   | boolean        | `false`     | Whether the tool returns a JSON response instead of plain text. You must include the word 'json' in the body of the prompt                               |
 
 ### FreeForm Parameters
 

--- a/src/exec.js
+++ b/src/exec.js
@@ -75,8 +75,7 @@ async function streamExecWithEvents(command, args, stdin, cwd = './', env) {
         const namedPipe = '\\\\.\\pipe\\gptscript-' + Math.floor(Math.random() * 1000000);
         events = new stream.Readable({
             encoding: 'utf-8',
-            read() {
-            }
+            read() {}
         });
 
          server = net.createServer((connection) => {

--- a/src/request.js
+++ b/src/request.js
@@ -1,0 +1,157 @@
+const http = require('http');
+const stream = require('stream');
+
+async function makeRequest(path, tool, opts = {}) {
+	let stdout = '';
+	const postData = JSON.stringify({ ...tool, ...opts });
+	const options = requestOptions(path, postData, tool, opts);
+
+	const p = new Promise((resolve, reject) => {
+		const req = http.request(options, (res) => {
+			res.on('data', (chunk) => {
+				stdout += chunk;
+			});
+
+			res.on('end', () => {
+				resolve();
+			})
+		});
+
+		req.on('error', (error) => {
+			reject(`Error making ${options.method} request: ${error.message}`);
+		});
+
+		req.write(postData);
+		req.end();
+	})
+
+	await p;
+	const respObj = JSON.parse(stdout);
+	if (respObj.error) {
+		throw new Error(respObj.error);
+	}
+
+	return respObj.output;
+}
+
+async function makeStreamRequest(path, tool, opts = {}) {
+	const stdout = new stream.Readable({
+		encoding: 'utf-8',
+		read() {}
+	});
+	const stderr = new stream.Readable({
+		encoding: 'utf-8',
+		read() {}
+	});
+
+	const postData = JSON.stringify({ ...tool, ...opts });
+	const options = requestOptions(path, postData, tool, opts);
+
+	const p = new Promise((resolve, reject) => {
+		const req = http.request(options, (res) => {
+			res.on('data', (chunk) => {
+				const c = chunk.toString().replace(/^(data: )/,"").trim();
+				if (c === 'DONE') {
+				} else if (c.startsWith('{"stderr":')) {
+					stderr.push(JSON.parse(c).stderr);
+				} else {
+					stdout.push(JSON.parse(c).stdout);
+				}
+			});
+
+			res.on('end', () => {
+				resolve();
+			})
+		});
+
+		req.on('error', (error) => {
+			reject(`Error making ${options.method} request: ${error.message}`);
+		});
+
+		req.write(postData);
+		req.end();
+	})
+
+	return {
+		stdout: stdout,
+		stderr: stderr,
+		promise: p
+	}
+}
+
+async function makeStreamRequestWithEvents(path, tool, opts = {}) {
+	const stdout = new stream.Readable({
+		encoding: 'utf-8',
+		read() {}
+	});
+	const stderr = new stream.Readable({
+		encoding: 'utf-8',
+		read() {}
+	});
+	const events = new stream.Readable({
+		encoding: 'utf-8',
+		read() {}
+	});
+
+	const postData = JSON.stringify({ ...tool, ...opts });
+	const options = requestOptions(path, postData, tool, opts);
+
+	const p = new Promise((resolve, reject) => {
+		const req = http.request(options, (res) => {
+			res.on('data', (chunk) => {
+				const c = chunk.toString().replace(/^(data: )/,"").trim();
+				if (c === 'DONE') {
+				} else if (c.startsWith('{"stderr":')) {
+					stderr.push(JSON.parse(c).stderr);
+				} else if (c.startsWith('{"stdout":')) {
+					stdout.push(JSON.parse(c).stdout);
+				} else {
+					events.push(c+"\n");
+				}
+			});
+
+			res.on('end', () => {
+				resolve();
+			})
+		});
+
+		req.on('error', (error) => {
+			reject(`Error making ${options.method} request: ${error.message}`);
+		});
+
+		req.write(postData);
+		req.end();
+	})
+
+	return {
+		stdout: stdout,
+		stderr: stderr,
+		events: events,
+		promise: p
+	}
+}
+
+function requestOptions(path, postData, tool, opts = {}) {
+	let method = 'GET';
+	if (tool) {
+		method = 'POST';
+	}
+
+	return {
+		hostname: process.env['GPTSCRIPT_URL'],
+		port: parseInt(process.env['GPTSCRIPT_PORT'] || '8080'),
+		protocol: process.env['GPTSCRIPT_PROTOCOL'] || 'http:',
+		path: '/' + path,
+		method: method,
+		headers: {
+			'Content-Type': 'application/json',
+			'Content-Length': Buffer.byteLength(postData),
+		},
+	};
+}
+
+module.exports = {
+	makeStreamRequestWithEvents: makeStreamRequestWithEvents,
+	makeStreamRequest: makeStreamRequest,
+	makeRequest: makeRequest
+}

--- a/tests/gptscript.test.js
+++ b/tests/gptscript.test.js
@@ -4,8 +4,8 @@ const path = require('path');
 describe('gptscript module', () => {
 
     beforeAll(() => {
-        if (!process.env.OPENAI_API_KEY) {
-            throw new Error("OPENAI_API_KEY is not set");
+        if (!process.env.OPENAI_API_KEY && !process.env.GPTSCRIPT_URL) {
+            throw new Error("neither OPENAI_API_KEY nor GPTSCRIPT_URL is set");
         }
     });
 
@@ -38,7 +38,7 @@ describe('gptscript module', () => {
             instructions: "who was the president of the united states in 1928?"
         });
         const opts = {
-            cache: false
+            disableCache: true
         }
 
         try {
@@ -66,7 +66,7 @@ describe('gptscript module', () => {
             instructions: "who was the president of the united states in 1928?"
         });
         const opts = {
-            cache: false
+            disableCache: true
         }
 
         try {
@@ -124,11 +124,11 @@ describe('gptscript module', () => {
         let err = "";
         const testGptPath = path.join(__dirname, 'fixtures', 'test.gpt');
         const opts = {
-            cache: false
+            disableCache: true
         }
 
         try {
-            const { stdout, stderr, promise } = await gptscript.streamExecFile(testGptPath, opts);
+            const { stdout, stderr, promise } = await gptscript.streamExecFile(testGptPath, "", opts);
             stdout.on('data', data => {
                 out += `system: ${data}`;
             });
@@ -150,11 +150,11 @@ describe('gptscript module', () => {
         let event = "";
         const testGptPath = path.join(__dirname, 'fixtures', 'test.gpt');
         const opts = {
-            cache: false
+            disableCache: true
         }
 
         try {
-            const { stdout, stderr, events, promise } = await gptscript.streamExecFileWithEvents(testGptPath, opts);
+            const { stdout, stderr, events, promise } = await gptscript.streamExecFileWithEvents(testGptPath, "", opts);
             stdout.on('data', data => {
                 out += `system: ${data}`;
             });


### PR DESCRIPTION
This change introduces the ability to use a remote server for executing the gptscript commands instead of a fork/exec model. Setting GPTSCRIPT_URL to the host of an SDK server will run the commands on the server instead.