### PR TITLE
Update default gptscript binary path

### DIFF
--- a/src/gptscript.ts
+++ b/src/gptscript.ts
@@ -902,7 +902,7 @@ async function getCmdPath(): Promise<string> {
 
 	const path = await import("path")
 	const url = await import("url")
-	return path.join(path.dirname(url.fileURLToPath(import.meta.url)), "..", "bin", "gptscript")
+	return path.join(path.dirname(url.fileURLToPath(import.meta.url)), "..", "..", "bin", "gptscript")
 }
 
 function parseBlocksFromNodes(nodes: any[]): Block[] {


### PR DESCRIPTION
Fix #35 

After installing `@gptscript-ai/gptscript` as a library, the `gptscript` binary is located in:

```
./node_modules/@gptscript-ai/bin/gptscript
```

The default location set in `getCmdPath` only moves up one directory causing the route to be:

```
./node_modules/@gptscript-ai/gptscript/bin/gptscript
```

The incorrect location will cause an `ENOENT` error whenever calling a method that uses the gptscript binary:

<details open>

```console
Error: spawn <app>/node_modules/@gptscript-ai/gptscript/bin/gptscript ENOENT
```

</details>

This PR updates the default route by moving up one extra directory. 