### PR TITLE
fix: use node to run tests instead of jest directly

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "pretest": "npm run install-binary",
     "install-binary": "node scripts/install-binary.js",
-    "test": "NODE_OPTIONS='--experimental-vm-modules' jest",
+    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js",
     "postinstall": "node scripts/install-binary.js",
     "clean": "rm -rf dist",
     "build": "tsc"


### PR DESCRIPTION
This makes npm test compatible with windows.