### PR TITLE
enhance: support credential override

### DIFF
--- a/src/gptscript.ts
+++ b/src/gptscript.ts
@@ -37,6 +37,7 @@ export interface RunOpts {
 	chatState?: string
 	confirm?: boolean
 	prompt?: boolean
+    credentialOverride?: string
 	env?: string[]
 
 	APIKey?: string

--- a/tests/fixtures/credential-override.gpt
+++ b/tests/fixtures/credential-override.gpt
@@ -1,0 +1,5 @@
+credentials: github.com/gptscript-ai/credential as test.ts.credential_override with TEST_CRED as env
+
+#!/usr/bin/env bash
+
+echo "${TEST_CRED}"

--- a/tests/gptscript.test.ts
+++ b/tests/gptscript.test.ts
@@ -106,6 +106,18 @@ describe("gptscript module", () => {
 		expect(result).toContain("Calvin Coolidge")
 	})
 
+	test("should override credentials correctly", async () => {
+		const testGptPath = path.join(__dirname, "fixtures", "credential-override.gpt")
+
+		const result = await (await g.run(testGptPath, {
+      disableCache: true,
+      credentialOverride: 'test.ts.credential_override:TEST_CRED=foo',
+    })).text()
+
+		expect(result).toBeDefined()
+		expect(result).toContain("foo")
+	})
+
 	test("run executes and stream a file correctly", async () => {
 		let out = ""
 		let err = undefined
@@ -166,6 +178,7 @@ describe("gptscript module", () => {
 		expect(errMessage).toContain("aborted")
 		expect(err).toBeUndefined()
 	})
+
 
 	describe("evaluate with multiple tools", () => {
 		test("multiple tools", async () => {


### PR DESCRIPTION
Enable users to set credential overrides on `run`.

e.g.

```typescript
const g = new gptscript.GPTScript();
try {
  const run = await g.run('./test.gpt', {
    disableCache: true,
    credentialOverride: "sys.openai:OPENAI_API_KEY",
  });
  console.log(await run.text());
} catch (e) {
  console.error(e);
}
g.close();
```

```yaml
tools: github.com/gptscript-ai/dalle-image-generation

You are an expert in image generation. Please generate a lion standing proudly in the savannah.
```

Addresses https://github.com/gptscript-ai/gptscript/issues/553 for `node-gptscript`
