### PR TITLE
fix: put metadata on tool def

### DIFF
--- a/src/gptscript.ts
+++ b/src/gptscript.ts
@@ -680,6 +680,7 @@ export interface ToolDef {
     credentials?: string[]
     instructions?: string
     type?: string
+    metaData?: Record<string, string>
 }
 
 export interface ToolReference {
@@ -695,7 +696,6 @@ export interface Tool extends ToolDef {
     id: string
     type: typeof ToolType
     toolMapping?: Record<string, ToolReference[]>
-    metaData?: Record<string, string>
     localTools?: Record<string, string>
     source?: SourceRef
     workingDir?: string

--- a/tests/gptscript.test.ts
+++ b/tests/gptscript.test.ts
@@ -361,8 +361,8 @@ describe("gptscript module", () => {
 
         const inputs = [
             "List the 3 largest of the Great Lakes by volume.",
-            "What is the volume of the second one in cubic miles?",
-            "What is the total area of the third one in square miles?"
+            "What is the volume of the second in the list in cubic miles?",
+            "What is the total area of the third in the list in square miles?"
         ]
 
         const expectedOutputs = [
@@ -560,6 +560,22 @@ describe("gptscript module", () => {
         let err = undefined
         let out = ""
         let run = await g.run(path.join(__dirname, "fixtures", "parse-with-metadata.gpt"))
+
+        try {
+            out = await run.text()
+        } catch (e) {
+            err = e
+        }
+        expect(err).toEqual(undefined)
+        expect(out).toEqual("200")
+    }, 20000)
+
+    test("run parsed tool with metadata", async () => {
+        let err = undefined
+        let out = ""
+        let tools = await g.parse(path.join(__dirname, "fixtures", "parse-with-metadata.gpt"))
+
+        let run = await g.evaluate(tools[0])
 
         try {
             out = await run.text()


### PR DESCRIPTION
This allows the following flow to work for tools with metadata: parse file -> pass tools from parsed file to evaluate.