### PR TITLE
fix: override knowledge credential in test

### DIFF
--- a/tests/gptscript.test.ts
+++ b/tests/gptscript.test.ts
@@ -204,6 +204,7 @@ describe("gptscript module", () => {
         const testGptPath = path.join(__dirname, "fixtures", "global-tools.gpt")
         const opts = {
             disableCache: true,
+            credentialOverrides: ["github.com/gptscript-ai/gateway:OPENAI_API_KEY"]
         }
 
         const run = await g.run(testGptPath, opts)


### PR DESCRIPTION
The knowledge tool isn't actually used in the test, but it is a good example of a large tool, so it is included.